### PR TITLE
Descriptive metadata files

### DIFF
--- a/abstract.rst
+++ b/abstract.rst
@@ -1,0 +1,38 @@
+Abstract
+********
+
+This provisional Biogeographic Analysis Package provides an analysis of protection status for ecological systems within Omernik Level III Ecoregions.  The  ecological system classification defines groups of plant communities that tend to co-occur within landscapes with similar ecological processes, substrates, and/or environmental gradients and is the primary map class used in the Gap Analysis Program (GAP) land cover layer (based on 2001 satellite imagery).  This package can be used to identify the ecoregions where ecological systems have the greatest representation in GAP Status 1 and 2 lands (lands managed for the protection of biodiversity) and the ecoregions where ecological systems are the least protected.
+
+One important use of the data in this Biogeographic Analysis Package is to evaluate what proportion of the ecological systems in an ecoregion are managed for long-term conservation. These data can be expressed as “threshold” levels of ecological system protection. These thresholds provide a convenient reporting framework. The following thresholds of ecological systems protection are used in this Biogeographic Analysis Package. For definitions of GAP Status codes see:  https://www.sciencebase.gov/vocab/vocabulary/56db17ede4b0c798f3c8b712.
+
+* Threshold 1: Less than 1% of ecological system is on GAP Status 1 and 2 lands (least protected).
+* Threshold 2: From 1% to less than 10% is on GAP Status 1 and 2 lands.
+* Threshold 3: Between 10% and less than 17%* is on GAP Status 1 and 2 lands.
+* Threshold 4: Between 17% and 50% is on GAP Status 1 and 2 lands or on GAP Status 1, 2, and 3 lands.
+* Threshold 5: More than 50% of ecological system is on GAP Status 1, 2, and 3 lands (most protected).
+
+
+Note: 17% represents the 2020 target threshold for protection of terrestrial ecosystems agreed upon by Parties to the Conservation on Biological Diversity during the Aichi Convention.   < https://www.cbd.int/sp/targets/>
+
+
+Data Use Constraints
+====================
+
+These provisional data were compiled with regard to the following standards and appropriate uses. Please be aware of the limitations of the data.
+
+* These data are meant to be used at a scale of 1:100,000 or smaller (such as 1:250,000 or 1:500,000) for the purpose of assessing the conservation status of animals and vegetation types over large geographic regions.
+* ​All information is created with a specific end use or uses in mind. For the Gap Analysis Program, minimum standards were set including: scale or resolution (1:100,000 or 100 hectare minimum mapping unit), accuracy (80% accurate at 95% confidence), and format (ARC/INFO coverage tiled to the 30' x 60' USGS quadrangle).
+* Scale: The data were produced with an intended application at the ecoregion level, that is, geographic areas from several hundred thousand to millions of hectares in size. The data provide a coarse-filter approach to analysis, meaning that not every occurrence of every plant community or animal species habitat is mapped, only larger, more generalized distributions.
+​* The data are also based on the USGS 1:100,000 scale of mapping in both detail and precision. When determining whether to apply GAP data to a particular use, there are two primary questions: Do you want to use the data as a map for the particular geographic area, or do you wish to use the data to provide context for a particular area? The example below illustrates two appropriate uses of the data: as a coarse map for a large area such as a county and to provide context for finer-level maps.
+* You could use GAP land cover to determine the approximate amount of oak woodland occurring in a county, or you could map oak woodland with aerial photography to determine the exact amount. You then could use GAP data to determine the approximate percentage of all oak woodland in the region or state that occurs in the county, and thus gain a sense of how important the county's distribution is to maintaining that plant community.
+
+
+Appropriate uses
+----------------
+
+statewide biodiversity planning; regional habitat conservation planning; large-area resource management planning; coarse-filter evaluation of potential impacts/benefits of major projects on biodiversity (e.g., utility or transportation corridors, wilderness proposals, recreation proposals); determining relative amounts of management responsibility for specific biological resources among land stewards to facilitate cooperative management and planning; basic research on regional distributions of plants and animals and to help target both specific species and geographic areas for needed research; environmental impact assessment for large projects or military activities; and estimation of potential economic impacts from loss of biological resource-based activities.
+
+Inappropriate uses
+------------------
+
+There is a "fuzzy line" that is eventually crossed when the differences in resolution of the data, size of geographic area being analyzed, and precision of the answer required for the question are no longer compatible. Examples of inappropriate uses include: using the data to map small areas (less than thousands of hectares), typically requiring mapping resolution at 1:24,000 scale and using aerial photographs or ground surveys; combining GAP data with other data finer than 1:100,000 scale to produce new hybrid maps or answer queries; generating specific areal measurements from the data finer than the nearest thousand hectares (minimum mapping unit size and accuracy affect this precision); establishing exact boundaries for regulation or acquisition; establishing definite occurrence or non-occurrence of any feature for an exact geographic area (for land cover, the percent accuracy will provide a measure of probability); determining abundance, health, or condition of any feature; and establishing a measure of accuracy of any other data by comparison with GAP data.

--- a/authors.json
+++ b/authors.json
@@ -1,0 +1,73 @@
+[
+    {
+        "name": "Alexa McKerrow",
+        "oldPartyId": 6780,
+        "type": "Author",
+        "contactType": "person",
+        "email": "amckerrow@usgs.gov",
+        "active": true,
+        "firstName": "Alexa",
+        "lastName": "McKerrow",
+        "cellPhone": "5712185474",
+        "organization": {
+            "displayText": "Biogeographic Characterization"
+        },
+        "primaryLocation": {
+            "name": "Alexa McKerrow/BRD/USGS/DOI - Primary Location",
+            "building": "Bldg Record",
+            "buildingCode": "AVD",
+            "officePhone": "9195132853",
+            "faxPhone": "9195154454",
+            "streetAddress": {
+                "line1": "David Clark Labs, NC State Univ",
+                "city": "Raleigh",
+                "state": "NC",
+                "zip": "27695-7617"
+            },
+            "mailAddress": {
+                "line1": "NC Coop F&W Res Unit, NC St Univ, Dept of Zoology, Campus Box 7617",
+                "city": "Raleigh",
+                "state": "NC",
+                "zip": "27695-7617",
+                "country": "USA"
+            }
+        },
+        "orcId": "0000-0002-8312-2905"
+    },
+    {
+        "name": "Julie S Prior-Magee",
+        "oldPartyId": 8296,
+        "type": "Author",
+        "contactType": "person",
+        "email": "jpmagee@usgs.gov",
+        "active": true,
+        "firstName": "Julie",
+        "middleName": "S",
+        "lastName": "Prior-Magee",
+        "organization": {
+            "displayText": "Biogeographic Characterization"
+        },
+        "primaryLocation": {
+            "name": "Julie S Prior-Magee/BRD/USGS/DOI - Primary Location",
+            "building": "Knox Hall NM State Univ",
+            "buildingCode": "KGL",
+            "officePhone": "5755571566",
+            "faxPhone": "5756461281",
+            "streetAddress": {
+                "line1": "2980 Espina St, NM State Univ Knox Hall",
+                "city": "Las Cruces",
+                "state": "NM",
+                "zip": "99003"
+            },
+            "mailAddress": {
+                "line1": "P.O. Box 30003, Dept. 4901, Mail Stop 4901",
+                "mailStopCode": "4901",
+                "city": "Las Cruces",
+                "state": "NM",
+                "zip": "88003",
+                "country": "USA"
+            }
+        },
+        "orcId": "0000-0003-4031-1885"
+    }
+]

--- a/temp-get-authors.py
+++ b/temp-get-authors.py
@@ -1,0 +1,12 @@
+'''
+This is a temporary way to grab up a set of contact details from an item in ScienceBase and dump it out to a file called authors.json that serves as an example of a standard file we would look for in an Analysis Package. A better solution would be to store this in something more standardized like json-ld syntax referencing schema.org person. The idea is we want a way of storing full details for the authors of an analysis package in a file for slurping up in various routines. This is one possible way to get there.
+'''
+
+import requests
+import json
+
+item = requests.get('https://www.sciencebase.gov/catalog/item/5645fa07e4b0e2669b30f267?format=json&fields=contacts').json()
+
+with open('authors.json', 'w') as fp:
+    json.dump(item['contacts'], fp, indent=4)
+    fp.close()


### PR DESCRIPTION
I'm experimenting with a way to add descriptive metadata to the repo for an analysis package. We want to do away with building this information and the identities for BAPs in ScienceBase, relying fully on what we can pull from the repo where code and documentation are all based. The main thing we are putting in ScienceBase Items today are the following:

* Abstract
* Authors (contacts)
* Links

So far, I added an abstract as a reStructureText (rst) file called "abstract.rst." It seemed reasonable to simply put this in as a single file with a standard name. We could potentially accept a number of formats, but since we are using rst in the nbmdocs and there are ready tools to transform it into any number of other formats, it seemed reasonable.

I also added an authors.json file mostly as a placeholder. I simply pulled the contacts array from one of the relevant ScienceBase Items and output it as a JSON document. If we're going to do something like this, it would be better to structure that in something more standard like json-ld with appropriate schema.org context for person or organization. I am also thinking it would be good to combine a structured file like this with interrogation of the repo itself for contributors. We need to give analysis authors a place to record how they want the information about the analysis package to be represented, but it would also be good to let the repos speak for themselves. These two avenues should ultimately line up in some way, we hope.

I haven't dealt with links yet, but I was thinking to go in the direction of a standard format for citations (e.g., RIS, EndNote, etc.). Citations are kind of the most important reason we've used webLinks in ScienceBase items for the BAPs so far. Those citation formats are kind of dumb and old at this point, but they are simple and they are a standard export format from tools like Zotero, Mendeley, and others.

I can also envision some folks accusing me of reinventing the wheel here instead of just using something like ISO19115 or even FGDC-CSDGM and adapting those common metadata encodings for a software description dialect. There's some validity to that argument, and there are some groups working on just that dynamic. However, I tend to think we will get this process further by simply focusing on the few pieces of standardized documentation we need, leveraging the construct of a GitHub repo as the packager, and using common and simple design patterns for the components of documentation.